### PR TITLE
Don't panic when the stats file is not created or has no stats.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ pub struct Entry {
 	dirs: HashMap<PathBuf,u32>,
 }
 
-#[derive(Deserialize,Debug)]
+#[derive(Deserialize,Debug,Default)]
 pub struct Entries(Vec<Entry>);
 
 impl Entries {
@@ -306,7 +306,7 @@ fn main() {
 		println!("{raw}");
 		return
 	}
-	let entries: Entries = serde_json::from_str(&raw).unwrap();
+	let entries: Entries = serde_json::from_str(&raw).unwrap_or_default();
 	let mut cmd_stats = CmdStats { entries, cli };
 	cmd_stats.print_entries();
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -48,21 +48,25 @@ impl Table {
 	}
 	pub fn calc_cell_widths(&self) -> Vec<usize> {
 		let mut widths = vec![];
+		Self::update_cell_widths(&mut widths, self.headings.iter().map(|s| s.as_str()));
 		for row in &self.rows {
 			let Row { cells } = &row;
 			assert!(cells.len() == self.columns);
-			for (i, cell) in cells.iter().enumerate() {
-				let visible_width: usize = console::strip_ansi_codes(&cell.content).width();
-				if let Some(width) = widths.get(i) {
-					if visible_width > *width {
-						widths[i] = visible_width;
-					}
-				} else {
-					widths.insert(i, visible_width);
-				}
-			}
+			Self::update_cell_widths(&mut widths, cells.iter().map(|c| c.content.as_str()));
 		}
 		widths
+	}
+	fn update_cell_widths<'a>(widths: &mut Vec<usize>, cells: impl IntoIterator<Item = &'a str>) {
+		for (i, cell) in cells.into_iter().enumerate() {
+			let visible_width: usize = console::strip_ansi_codes(cell).width();
+			if let Some(width) = widths.get(i) {
+				if visible_width > *width {
+					widths[i] = visible_width;
+				}
+			} else {
+				widths.insert(i, visible_width);
+			}
+		}
 	}
 	pub fn set_sort_column(&mut self, col_idx: usize) {
 		self.sort_by = Some(col_idx)


### PR DESCRIPTION
Hi, I wanted to start using this and I immediately encountered those two panics.

In the case of the missing file or invalid json, you may want to print error instead of just printing empty stats.

The second panic happened because if the stats file is empty, than the vector with column widths is empty and it will panic when indexed while printing the headings.